### PR TITLE
💄 (#6) Design: 헤더와 메인 겹치는 문제 해결

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -11,10 +11,8 @@ const Layout = ({ children }) => {
     bg-gray">
       {/* 화면 상단에 고정되는 헤더 */}
       <Header />
-      
-
       {/* 페이지의 실제 내용과 푸터가 이 안에서 스크롤됩니다. */}
-      <main className="flex-grow overflow-y-auto">
+      <main className="flex-grow overflow-y-auto pt-[54px]">
         {/* 1. 페이지의 실제 내용 (Home, Board 등) */}
         {children}
 


### PR DESCRIPTION
## ✨ 작업 개요
- 헤더와 메인 겹치는 것 pt 줌

## ✅ 주요 작업 내용
- pt-[54px]

## 🔄 관련 이슈
#6 

## 📸 스크린샷 (선택)
<img width="986" height="660" alt="image" src="https://github.com/user-attachments/assets/174b7415-1110-4c80-88a2-578c8a28e596" />

## 📝 비고
- (버그, 추후 개선사항 등)