### PR TITLE
🐛 (#86) fix: 좋아요랑 상세페이지로 넘어가는 onclick 겹침 해결

### DIFF
--- a/src/components/MapComponents/BoothCard.jsx
+++ b/src/components/MapComponents/BoothCard.jsx
@@ -4,7 +4,7 @@ import UnheartIcon from "../../assets/images/icons/map-icons/Unheart.svg";
 import Badge from "./BoothCardComponents/Badge";
 import useLikes from "../../hooks/MapHooks/useLikes";
 
-const BoothCard = ({
+function BoothCard({
   boothId,
   title,
   image,
@@ -18,8 +18,8 @@ const BoothCard = ({
   isLiked: initialIsLiked,
   isEvent,
   isDorder,
-  onClick
-}) => {
+  onClick,
+}) {
   const { isLiked, likesCount, toggleLike, loading } = useLikes(
     boothId,
     initialIsLiked,
@@ -34,7 +34,6 @@ const BoothCard = ({
         boxShadow: "0 3px 5px 0 rgba(0, 0, 0, 0.10)",
       }}
       onClick={onClick}
-      
     >
       <div className="flex gap-4 items-center h-full">
         {/* 이미지 */}
@@ -47,20 +46,26 @@ const BoothCard = ({
             />
           </div>
           {/* Badge 겹치기 */}
-          {isEvent ?
+          {isEvent ? (
             <div className="absolute top-0 left-0 -translate-x-1/4 -translate-y-1/2">
               <Badge backgroundColor=" rgba(239, 112, 99, 0.90)" text="Event" />
-            </div>:null
-          }
+            </div>
+          ) : null}
         </div>
-        
+
         {/* 글자 */}
         <div className="flex-1  relative">
           <div className="absolute top-0 right-0 flex flex-col items-center">
             <button
-              onClick={toggleLike}
+              onClick={(e) => {
+                e.stopPropagation(); // 카드 onClick으로 전파 차단
+                e.preventDefault(); // (카드가 <Link>로 감싸졌다면 이동 차단)
+                if (!loading) toggleLike();
+              }}
               disabled={loading}
               className="w-6 h-6 flex items-center justify-center mb-1 hover:scale-110 transition-transform duration-200 disabled:opacity-50"
+              aria-pressed={isLiked}
+              aria-label={isLiked ? "좋아요 취소" : "좋아요"}
             >
               <img
                 src={isLiked ? HeartIcon : UnheartIcon}
@@ -97,6 +102,6 @@ const BoothCard = ({
       </div>
     </div>
   );
-};
+}
 
 export default BoothCard;

--- a/src/components/MapComponents/PullList.jsx
+++ b/src/components/MapComponents/PullList.jsx
@@ -141,7 +141,6 @@ function PullList({ booths, selectedFilter, searchTerm, selectedPin }) {
       : 1;
     return aMatch - bMatch;
   });
-  console.log("PullList searchTerm:", searchTerm); // <- 이거 찍어보기
 
   return (
     <div
@@ -205,7 +204,7 @@ function PullList({ booths, selectedFilter, searchTerm, selectedPin }) {
                     isOperating={booth.isOperating}
                     isDorder={booth.is_dorder}
                     isEvent={booth.is_event}
-                    likesCount={booth.likes_count} //좋아요 개수
+                    likesCount={booth.likes_cnt} //좋아요 개수
                     isLiked={booth.is_liked} //좋아요 눌렀는지
                     className="w-full"
                     onClick={() =>

--- a/src/hooks/MapHooks/useLikes.js
+++ b/src/hooks/MapHooks/useLikes.js
@@ -14,7 +14,7 @@ const useLikes = (boothId, initialLiked, initialCount = 0) => {
 
     try {
       const response = await axios.post(
-        `${import.meta.env.VITE_API_BASE_URL}/booths/${boothId}/like/`,
+        `${import.meta.env.VITE_API_BASE_URL}/booths/${boothId}/likes/`,
         {},
         { headers: { "Content-Type": "application/json" } }
       );


### PR DESCRIPTION
## ✨ 작업 개요
-  좋아요랑 상세페이지로 넘어가는 onclick 겹침 해결

## ✅ 주요 작업 내용
- 클릭 막기

## 🔄 관련 이슈
Closes #이슈번호

## 📸 스크린샷 (선택)
> before / after 비교가 있으면 같이 첨부해주세요

## 📝 비고
- 백엔드 like_cnt랑 likes_count 다름