### PR TITLE
💄 상세페이지 카드 triangle 추가 및 지도 탭 활성화 조건 수정

### DIFF
--- a/src/components/BottomNav/BottomNav.jsx
+++ b/src/components/BottomNav/BottomNav.jsx
@@ -33,10 +33,9 @@ const BottomNav = () => {
     w-[55px] h-[55px] px-[5px]
     whitespace-nowrap
     font-normal text-[12px]
-    ${
-      active
-        ? "text-orange font-semibold border-t-[1.5px] border-orange"
-        : "text-black"
+    ${active
+      ? "text-orange font-semibold border-t-[1.5px] border-orange"
+      : "text-black"
     }
   `;
 
@@ -44,7 +43,19 @@ const BottomNav = () => {
     <nav className="fixed bottom-0 z-999 w-full max-w-[430px] bg-white">
       <div className="flex items-start justify-around h-[62px]">
         {navItems.map((item) => {
-          const isActive = location.pathname === item.path;
+          let isActive;
+          if (item.path === "/map") {
+            // 지도 상세페이지들도 활성화 유지
+            isActive =
+              location.pathname.startsWith("/map") ||
+              location.pathname.startsWith("/booth") ||
+              location.pathname.startsWith("/drink") ||
+              location.pathname.startsWith("/foodtruck") ||
+              location.pathname.startsWith("/toilet");
+          } else {
+            isActive = location.pathname === item.path;
+          }
+
           return (
             <Link
               to={item.path}

--- a/src/pages/Map/DetailSections/DrinkDetail.jsx
+++ b/src/pages/Map/DetailSections/DrinkDetail.jsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
+
 import MenuSection from "./MenuSection";
 import NearbyBoothSection from "./NearbyBoothSection";
+
 import TimeCircleIcon from "../../../assets/images/icons/map-icons/TimeCircle.svg";
 import LocationIcon from "../../../assets/images/icons/map-icons/Location.svg";
+import TailIcon from "../../../assets/images/icons/map-icons/triangle.svg";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 const fmtTime = (t) => (typeof t === "string" ? t.slice(0, 5) : t);
@@ -41,7 +44,11 @@ export default function DrinkDetail() {
     useEffect(() => {
         axios
             .get(`${BASE_URL}/booths/detail/${id}/`)
-            .then((res) => setDrink(res.data));
+            .then((res) => setDrink(res.data))
+            .catch((err) => {
+                console.error("DrinkDetail API 실패", err);
+                setDrink(null);
+            });
     }, [id]);
 
     if (!drink) return <div className="p-6">로딩 중...</div>;
@@ -49,12 +56,15 @@ export default function DrinkDetail() {
     return (
         <div className="pt-6 pb-8">
             {/* 상단 이미지 */}
-            <div className="w-[343px] h-[232px] mx-auto bg-gray-200 flex items-center justify-center text-gray-500">
+            <div className="w-[343px] h-[232px] mx-auto bg-gray-200 flex items-center justify-center text-gray-500 rounded-[16px] overflow-hidden">
                 {drink.image_url ? (
                     <img
                         src={drink.image_url}
                         alt={drink.name}
                         className="w-[343px] h-[232px] object-cover"
+                        onError={(e) => {
+                            e.currentTarget.style.display = "none"; // 로딩 실패 시 숨김
+                        }}
                     />
                 ) : (
                     "주류 부스 사진"
@@ -63,6 +73,13 @@ export default function DrinkDetail() {
 
             {/* 카드 */}
             <div className="bg-white shadow-md rounded-[16px] px-4 py-3 mx-4 mt-3 relative z-10">
+                {/* triangle tail */}
+                <img
+                    src={TailIcon}
+                    className="absolute -top-6 left-10 -translate-x-1/2"
+                    alt="tail"
+                />
+
                 <h1 className="text-lg font-bold">{drink.name}</h1>
 
                 {/* 운영 시간 (요일 묶음) */}

--- a/src/pages/Map/DetailSections/FoodTruckDetail.jsx
+++ b/src/pages/Map/DetailSections/FoodTruckDetail.jsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
+
 import MenuSection from "./MenuSection";
 import NearbyBoothSection from "./NearbyBoothSection";
+
 import TimeCircleIcon from "../../../assets/images/icons/map-icons/TimeCircle.svg";
 import LocationIcon from "../../../assets/images/icons/map-icons/Location.svg";
+import TailIcon from "../../../assets/images/icons/map-icons/triangle.svg";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 const fmtTime = (t) => (typeof t === "string" ? t.slice(0, 5) : t);
@@ -39,7 +42,13 @@ export default function FoodTruckDetail() {
     const [truck, setTruck] = useState(null);
 
     useEffect(() => {
-        axios.get(`${BASE_URL}/booths/detail/${id}/`).then((res) => setTruck(res.data));
+        axios
+            .get(`${BASE_URL}/booths/detail/${id}/`)
+            .then((res) => setTruck(res.data))
+            .catch((err) => {
+                console.error("FoodTruckDetail API 실패", err);
+                setTruck(null);
+            });
     }, [id]);
 
     if (!truck) return <div className="p-6">로딩 중...</div>;
@@ -47,19 +56,38 @@ export default function FoodTruckDetail() {
     return (
         <div className="pt-6 pb-8">
             {/* 상단 이미지 */}
-            <div className="w-[343px] h-[232px] mx-auto bg-gray-200 flex items-center justify-center text-gray-500">
+            <div className="w-[343px] h-[232px] mx-auto bg-gray-200 flex items-center justify-center text-gray-500 rounded-[16px] overflow-hidden">
                 {truck.image_url ? (
-                    <img src={truck.image_url} alt={truck.name} className="w-[343px] h-[232px] object-cover" />
-                ) : "푸드트럭 사진"}
+                    <img
+                        src={truck.image_url}
+                        alt={truck.name}
+                        className="w-[343px] h-[232px] object-cover"
+                        onError={(e) => {
+                            e.currentTarget.style.display = "none"; // 로딩 실패 → 숨김
+                        }}
+                    />
+                ) : (
+                    "푸드트럭 사진"
+                )}
             </div>
 
             {/* 카드 */}
             <div className="bg-white shadow-md rounded-[16px] px-4 py-3 mx-4 mt-3 relative z-10">
+                {/* triangle tail */}
+                <img
+                    src={TailIcon}
+                    className="absolute -top-6 left-10 -translate-x-1/2"
+                    alt="tail"
+                />
+
                 <h1 className="text-lg font-bold">{truck.name}</h1>
 
-                {/* 운영 시간  */}
+                {/* 운영 시간 */}
                 {groupSchedules(truck.schedules).map((g, i) => (
-                    <div key={i} className="flex items-center gap-2 mt-1 text-sm text-gray-600">
+                    <div
+                        key={i}
+                        className="flex items-center gap-2 mt-1 text-sm text-gray-600"
+                    >
                         <img src={TimeCircleIcon} alt="time" className="w-4 h-4" />
                         <span>
                             {g.days.join(", ")} {g.time}

--- a/src/pages/Map/DetailSections/ToiletDetail.jsx
+++ b/src/pages/Map/DetailSections/ToiletDetail.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
+
 import NearbyBoothSection from "./NearbyBoothSection";
 import LocationIcon from "../../../assets/images/icons/map-icons/Location.svg";
-
+import TailIcon from "../../../assets/images/icons/map-icons/triangle.svg";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 const fmtTime = (t) => (typeof t === "string" ? t.slice(0, 5) : t);
@@ -13,7 +14,13 @@ export default function ToiletDetail() {
     const [toilet, setToilet] = useState(null);
 
     useEffect(() => {
-        axios.get(`${BASE_URL}/booths/detail/${id}/`).then((res) => setToilet(res.data));
+        axios
+            .get(`${BASE_URL}/booths/detail/${id}/`)
+            .then((res) => setToilet(res.data))
+            .catch((err) => {
+                console.error("ToiletDetail API 실패", err);
+                setToilet(null);
+            });
     }, [id]);
 
     if (!toilet) return <div className="p-6">로딩 중...</div>;
@@ -21,18 +28,38 @@ export default function ToiletDetail() {
     return (
         <div className="pt-6 pb-8">
             {/* 상단 이미지 */}
-            <div className="w-[343px] h-[232px] mx-auto bg-gray-200 flex items-center justify-center text-gray-500">
+            <div className="w-[343px] h-[232px] mx-auto bg-gray-200 flex items-center justify-center text-gray-500 rounded-[16px] overflow-hidden">
                 {toilet.image_url ? (
-                    <img src={toilet.image_url} alt={toilet.name} className="w-[343px] h-[232px] object-cover" />
-                ) : "화장실 사진"}
+                    <img
+                        src={toilet.image_url}
+                        alt={toilet.name}
+                        className="w-[343px] h-[232px] object-cover"
+                        onError={(e) => {
+                            e.currentTarget.style.display = "none"; // 로딩 실패 시 숨김
+                        }}
+                    />
+                ) : (
+                    "화장실 사진"
+                )}
             </div>
 
             {/* 카드 */}
             <div className="bg-white shadow-md rounded-[16px] px-4 py-3 mx-4 mt-3 relative z-10">
+                {/* triangle tail */}
+                <img
+                    src={TailIcon}
+                    className="absolute -top-6 left-10 -translate-x-1/2"
+                    alt="tail"
+                />
+
                 <h1 className="text-lg font-bold">{toilet.name}</h1>
 
+                {/* 운영 시간 */}
                 {toilet.schedules?.map((s, i) => (
-                    <div key={i} className="flex items-center gap-2 mt-1 text-sm text-gray-600">
+                    <div
+                        key={i}
+                        className="flex items-center gap-2 mt-1 text-sm text-gray-600"
+                    >
                         <span>
                             {s.day.slice(5)} {fmtTime(s.start_time)} ~ {fmtTime(s.end_time)}
                         </span>
@@ -46,10 +73,8 @@ export default function ToiletDetail() {
                 </div>
             </div>
 
-
             {/* 근처 부스 */}
             <NearbyBoothSection boothId={toilet.id} />
         </div>
     );
 }
-


### PR DESCRIPTION
## ✨ 작업 개요
- 부스 제외한 상세페이지에 triangle 말풍선 꼬리 추가
- 지도 -> 상세페이지 이동할 때도 하단바의 지도 아이콘 활성화되도록 수정